### PR TITLE
Feature/#28 queue ws events between connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ input devices (usually `input`), like this:
 ```
 sudo usermod -a -G input myusername
 ```
+
+## Configuration
+
+**barcode-server** uses [container-app-conf](https://github.com/markusressel/container-app-conf)
+to provide configuration via a YAML or TOML file as well as ENV variables. Have a look at the
+[documentation about it](https://github.com/markusressel/container-app-conf).
+
+The config file is searched for in the following locations (in this order):
+* `./`
+* `~/.config/`
+* `~/`
+
+See [barcode_server.yaml](/barcode_server.yaml) for an example in this repo.
+
 ## Native
 
 ```
@@ -52,6 +66,7 @@ When starting the docker container, make sure to pass through input devices:
 docker run \
   --name barcode \
   --device=/dev/input \
+  -v ./barcode_server.yaml:/app/barcode_server.yaml \
   -e PUID=0 \
   -e PGID=0 \
   markusressel/barcode-server

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ the approaches described below.
 In addition to the REST API **barcode-server** also exposes a websocket at `/`, which can be used
 to get realtime barcode scan events.
 
+To connect to it, you have to provide
+
+* a `Client-ID` header with a UUID (v4)
+* (optional) an empty `Drop-Event-Queue` header, to ignore events that happened between connections
+
 Messages received on this websocket are JSON formatted strings with the following format:
 ```json
 {
@@ -105,7 +110,7 @@ Messages received on this websocket are JSON formatted strings with the followin
 To test the connection you can use f.ex. `websocat`:
 
 ```
-> websocat - autoreconnect:ws://127.0.0.1:9654 --text --header "X-Auth-Token:EmUSqjXGfnQwn5wn6CpzJRZgoazMTRbMNgH7CXwkQG7Ph7stex"
+> websocat - autoreconnect:ws://127.0.0.1:9654 --text --header "Client-ID:dc1f14fc-a7a6-4102-af60-2b6e0dcf744c" --header "Drop-Event-Queue" --header "X-Auth-Token:EmUSqjXGfnQwn5wn6CpzJRZgoazMTRbMNgH7CXwkQG7Ph7stex"
 {"date":"2020-12-20T19:35:04.769739","device":{"name":"BARCODE SCANNER BARCODE SCANNER","path":"/dev/input/event3","vendorId":65535,"productId":53},"barcode":"D-t38409355843o52230Lm54784"}
 {"date":"2020-12-20T19:35:06.237408","device":{"name":"BARCODE SCANNER BARCODE SCANNER","path":"/dev/input/event3","vendorId":65535,"productId":53},"barcode":"4250168519463"}
 ```

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ To connect to it, you have to provide
 
 * a `Client-ID` header with a UUID (v4)
 * (optional) an empty `Drop-Event-Queue` header, to ignore events that happened between connections
+* (optional) an `X-Auth-Token` header, to authorize the client
 
 Messages received on this websocket are JSON formatted strings with the following format:
 ```json
@@ -110,7 +111,7 @@ Messages received on this websocket are JSON formatted strings with the followin
 To test the connection you can use f.ex. `websocat`:
 
 ```
-> websocat - autoreconnect:ws://127.0.0.1:9654 --text --header "Client-ID:dc1f14fc-a7a6-4102-af60-2b6e0dcf744c" --header "Drop-Event-Queue" --header "X-Auth-Token:EmUSqjXGfnQwn5wn6CpzJRZgoazMTRbMNgH7CXwkQG7Ph7stex"
+> websocat - autoreconnect:ws://127.0.0.1:9654 --text --header "Client-ID:dc1f14fc-a7a6-4102-af60-2b6e0dcf744c" --header "Drop-Event-Queue:" --header "X-Auth-Token:EmUSqjXGfnQwn5wn6CpzJRZgoazMTRbMNgH7CXwkQG7Ph7stex"
 {"date":"2020-12-20T19:35:04.769739","device":{"name":"BARCODE SCANNER BARCODE SCANNER","path":"/dev/input/event3","vendorId":65535,"productId":53},"barcode":"D-t38409355843o52230Lm54784"}
 {"date":"2020-12-20T19:35:06.237408","device":{"name":"BARCODE SCANNER BARCODE SCANNER","path":"/dev/input/event3","vendorId":65535,"productId":53},"barcode":"4250168519463"}
 ```

--- a/barcode_server/const.py
+++ b/barcode_server/const.py
@@ -13,6 +13,8 @@
 #  You should have received a copy of the GNU Affero General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+Client_Id = "Client-ID"
+Drop_Event_Queue = "Drop-Event-Queue"
 X_Auth_Token = "X-Auth-Token"
 
 CONFIG_NODE_ROOT = "barcode_server"

--- a/barcode_server/notifier/__init__.py
+++ b/barcode_server/notifier/__init__.py
@@ -74,6 +74,7 @@ class BarcodeNotifier:
                 while not success:
                     if datetime.now() - event.date >= self.drop_event_queue_after:
                         # event is older than threshold, so we just skip it
+                        self.event_queue.task_done()
                         break
 
                     try:

--- a/barcode_server/notifier/__init__.py
+++ b/barcode_server/notifier/__init__.py
@@ -1,7 +1,8 @@
 import asyncio
 import logging
-from asyncio import Task
+from asyncio import Task, QueueEmpty
 from datetime import datetime
+from typing import Optional
 
 from barcode_server.barcode import BarcodeEvent
 from barcode_server.config import AppConfig
@@ -19,7 +20,10 @@ class BarcodeNotifier:
         self.drop_event_queue_after = config.DROP_EVENT_QUEUE_AFTER.value
         self.retry_interval = config.RETRY_INTERVAL.value
         self.event_queue = asyncio.Queue()
-        self.processor_task: Task = None
+        self.processor_task: Optional[Task] = None
+
+    def is_running(self) -> bool:
+        return self.processor_task is not None
 
     async def start(self):
         """
@@ -36,6 +40,27 @@ class BarcodeNotifier:
 
         self.processor_task.cancel()
         self.processor_task = None
+
+    async def drop_queue(self):
+        """
+        Drops all items in the event queue
+        """
+        running = self.is_running()
+        # stop if currently running
+        if running:
+            await self.stop()
+
+        # mark all items as finished
+        for _ in range(self.event_queue.qsize()):
+            try:
+                self.event_queue.get_nowait()
+                self.event_queue.task_done()
+            except QueueEmpty as ex:
+                break
+
+        # restart if it was running
+        if running:
+            await self.start()
 
     async def event_processor(self):
         """
@@ -54,6 +79,7 @@ class BarcodeNotifier:
                     try:
                         await self._send_event(event)
                         success = True
+                        self.event_queue.task_done()
                     except Exception as ex:
                         LOGGER.exception(ex)
                         await asyncio.sleep(self.retry_interval.total_seconds())
@@ -73,3 +99,4 @@ class BarcodeNotifier:
         :param event: barcode event
         """
         raise NotImplementedError()
+

--- a/barcode_server/util.py
+++ b/barcode_server/util.py
@@ -4,6 +4,11 @@ from barcode_server.barcode import BarcodeEvent
 
 
 def input_device_to_dict(input_device: InputDevice) -> dict:
+    """
+    Converts an input device to a a dictionary with human readable values
+    :param input_device: the device to convert
+    :return: dictionary
+    """
     return {
         "name": input_device.name,
         "path": input_device.path,
@@ -13,6 +18,11 @@ def input_device_to_dict(input_device: InputDevice) -> dict:
 
 
 def barcode_event_to_json(event: BarcodeEvent) -> bytes:
+    """
+    Converts a barcode event to json
+    :param event: the event to convert
+    :return: json representation
+    """
     import orjson
 
     event = {
@@ -23,3 +33,26 @@ def barcode_event_to_json(event: BarcodeEvent) -> bytes:
 
     json = orjson.dumps(event)
     return json
+
+
+def is_valid_uuid(uuid_str: str):
+    """
+    Validates if the given string is a valid UUID version 4
+
+    :param uuid_str: the string to validate
+    :return: true if valid, false otherwise
+    """
+    try:
+        import uuid
+        val = uuid.UUID(uuid_str, version=4)
+    except ValueError:
+        # If it's a value error, then the string
+        # is not a valid hex code for a UUID.
+        return False
+
+    # If the uuid_string is a valid hex code,
+    # but an invalid uuid4,
+    # the UUID.__init__ will convert it to a
+    # valid uuid4. So we compare them again to
+    # make sure they are still the same.
+    return str(val) == uuid_str

--- a/barcode_server/util.py
+++ b/barcode_server/util.py
@@ -33,26 +33,3 @@ def barcode_event_to_json(event: BarcodeEvent) -> bytes:
 
     json = orjson.dumps(event)
     return json
-
-
-def is_valid_uuid(uuid_str: str):
-    """
-    Validates if the given string is a valid UUID version 4
-
-    :param uuid_str: the string to validate
-    :return: true if valid, false otherwise
-    """
-    try:
-        import uuid
-        val = uuid.UUID(uuid_str, version=4)
-    except ValueError:
-        # If it's a value error, then the string
-        # is not a valid hex code for a UUID.
-        return False
-
-    # If the uuid_string is a valid hex code,
-    # but an invalid uuid4,
-    # the UUID.__init__ will convert it to a
-    # valid uuid4. So we compare them again to
-    # make sure they are still the same.
-    return str(val) == uuid_str

--- a/barcode_server/webserver.py
+++ b/barcode_server/webserver.py
@@ -137,7 +137,10 @@ class Webserver:
         else:
             LOGGER.debug(
                 f"Previously seen client reconnected: {client_id} (from {request.host})")
+
         notifier = self.notifiers[client_id]
+        if isinstance(notifier, WebsocketNotifier):
+            notifier.websocket = websocket
 
         if Drop_Event_Queue in request.headers.keys():
             await notifier.drop_queue()

--- a/barcode_server/webserver.py
+++ b/barcode_server/webserver.py
@@ -15,7 +15,7 @@ from barcode_server.notifier.http import HttpNotifier
 from barcode_server.notifier.mqtt import MQTTNotifier
 from barcode_server.notifier.ws import WebsocketNotifier
 from barcode_server.stats import REST_TIME_DEVICES, WEBSOCKET_CLIENT_COUNT
-from barcode_server.util import input_device_to_dict, is_valid_uuid
+from barcode_server.util import input_device_to_dict
 
 LOGGER = logging.getLogger(__name__)
 routes = web.RouteTableDef()
@@ -93,11 +93,6 @@ class Webserver:
             return web.HTTPBadRequest()
 
         client_id = request.headers[Client_Id].lower().strip()
-
-        if not is_valid_uuid(client_id):
-            LOGGER.warning(
-                f"Rejecting client with invalid UUID '{request.headers[Client_Id]}': {request.host}")
-            return web.HTTPBadRequest()
 
         if self.clients.get(client_id, None) is not None:
             LOGGER.warning(

--- a/tests/websocket_notifier_test.py
+++ b/tests/websocket_notifier_test.py
@@ -65,10 +65,16 @@ class WebsocketNotifierTest(AioHTTPTestCase):
         sample_event = create_barcode_event_mock("abcdefg")
         expected_json = barcode_event_to_json(sample_event)
 
+        import uuid
+        client_id = str(uuid.uuid4())
+
         async with aiohttp.ClientSession() as session:
             async with session.ws_connect(
                     'http://127.0.0.1:9654/',
-                    headers={"X-Auth-Token": self.config.SERVER_API_TOKEN.value}) as ws:
+                    headers={
+                        "Client-ID": client_id,
+                        "X-Auth-Token": self.config.SERVER_API_TOKEN.value
+                    }) as ws:
                 asyncio.create_task(self.webserver.on_barcode(sample_event))
                 async for msg in ws:
                     if msg.type == aiohttp.WSMsgType.BINARY:


### PR DESCRIPTION
fixes #28

In theory we could make the Client-ID header optional and keep backwards compatibility, however, I don't think it is worth the time investment for now since there is no use case for it. So this PR is a **breaking change**.

Whats missing:
* [x] a test for dropping the event queue
* [ ] maybe a test with multiple connected clients?