### PR TITLE
Fix premature access of possibly non-existing attribute

### DIFF
--- a/barcode_server/keyevent_reader.py
+++ b/barcode_server/keyevent_reader.py
@@ -55,12 +55,14 @@ class KeyEventReader:
         for event in input_device.read_loop():
             event = categorize(event)
 
+            if hasattr(event, "event"):
+                if not hasattr(event, "keystate"):
+                    event.keystate = event.event.keystate
+
             if isinstance(event, KeyEvent):
                 if self._on_key_event(event):
                     return self._line
             elif hasattr(event, "event") and event.event.type == 1:
-                if not hasattr(event, "keystate"):
-                    event.keystate = event.event.keystate
                 if self._on_key_event(event):
                     return self._line
 

--- a/barcode_server/keyevent_reader.py
+++ b/barcode_server/keyevent_reader.py
@@ -54,7 +54,11 @@ class KeyEventReader:
         # async for event in input_device.async_read_loop():
         for event in input_device.read_loop():
             event = categorize(event)
-            if isinstance(event, KeyEvent) or event.event.type == 1:
+
+            if isinstance(event, KeyEvent):
+                if self._on_key_event(event):
+                    return self._line
+            elif hasattr(event, "event") and event.event.type == 1:
                 if not hasattr(event, "keystate"):
                     event.keystate = event.event.keystate
                 if self._on_key_event(event):

--- a/tests/key_event_reader_test.py
+++ b/tests/key_event_reader_test.py
@@ -125,3 +125,20 @@ class KeyEventReaderTest(TestBase):
 
         # THEN
         self.assertEqual(expected, line)
+
+    async def test_event_without_event_attribute(self):
+        # GIVEN
+        under_test = KeyEventReader()
+        expected = "0"
+        input_events = self.generate_input_event_sequence(expected)
+        for event in input_events:
+            delattr(event, "event")
+
+        input_device = Mock()
+        input_device.read_loop = self.fake_input_loop(input_events)
+
+        # WHEN
+        line = under_test.read_line(input_device)
+
+        # THEN
+        self.assertEqual(expected, line)


### PR DESCRIPTION
separate different event parsing methods more clearly
add attribute check to prevent crash

fixes #81 